### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ The complete documentation is available on [Godoc](https://pkg.go.dev/github.com
 ## How to Install
 
 ```shell script
-go get https://github.com/chidiwilliams/flatbson
+go get -v github.com/chidiwilliams/flatbson
 ```


### PR DESCRIPTION
This fixes a little typo that generates this error
```
package https:/github.com/chidiwilliams/flatbson: https:/github.com/chidiwilliams/flatbson: invalid import path: malformed import path "https:/github.com/chidiwilliams/flatbson": invalid char ':'
```